### PR TITLE
Fix item models

### DIFF
--- a/src/main/resources/assets/betterbuilderswands/models/item/wandDiamond.json
+++ b/src/main/resources/assets/betterbuilderswands/models/item/wandDiamond.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/handheld",
     "textures": {
         "layer0": "betterbuilderswands:items/wandDiamond"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/src/main/resources/assets/betterbuilderswands/models/item/wandIron.json
+++ b/src/main/resources/assets/betterbuilderswands/models/item/wandIron.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/handheld",
     "textures": {
         "layer0": "betterbuilderswands:items/wandIron"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/src/main/resources/assets/betterbuilderswands/models/item/wandStone.json
+++ b/src/main/resources/assets/betterbuilderswands/models/item/wandStone.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/handheld",
     "textures": {
         "layer0": "betterbuilderswands:items/wandStone"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/src/main/resources/assets/betterbuilderswands/models/item/wandUnbreakable.json
+++ b/src/main/resources/assets/betterbuilderswands/models/item/wandUnbreakable.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/handheld",
     "textures": {
         "layer0": "betterbuilderswands:items/wandUnbreakable"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }


### PR DESCRIPTION
Uses `item/handheld` as the parent instead of `builtin/generated` which fixes the in-hand models to be like Vanilla tools, and removes the need for the custom `display` block.

Old:
![2016-10-29_18 44 19](https://cloud.githubusercontent.com/assets/7091588/19833225/3c1d1a4e-9e08-11e6-8830-a2f976eddc48.png)

New:
![2016-10-29_18 46 29](https://cloud.githubusercontent.com/assets/7091588/19833228/3f6d42be-9e08-11e6-8da4-e14c60a4abad.png)
