### PR TITLE
Restore Botania compat

### DIFF
--- a/src/main/java/portablejim/bbw/containers/ContainerRegistrar.java
+++ b/src/main/java/portablejim/bbw/containers/ContainerRegistrar.java
@@ -12,7 +12,7 @@ public class ContainerRegistrar {
     public static void register() {
         BetterBuildersWandsMod.instance.containerManager.register(new HandlerCapability());
         if(Loader.isModLoaded("Botania") || Loader.isModLoaded("botania")) {
-            //BetterBuildersWandsMod.instance.containerManager.register(new HandlerBotania());
+            BetterBuildersWandsMod.instance.containerManager.register(new HandlerBotania());
         }
     }
 }

--- a/src/main/java/portablejim/bbw/containers/handlers/HandlerBotania.java
+++ b/src/main/java/portablejim/bbw/containers/handlers/HandlerBotania.java
@@ -28,7 +28,7 @@ public class HandlerBotania implements IContainerHandler {
     public int useItems(EntityPlayer player, ItemStack itemStack, ItemStack inventoryStack, int count) {
         IBlockProvider prov = (IBlockProvider) inventoryStack.getItem();
         if(prov.provideBlock(player, itemStack, inventoryStack, BasicPlayerShim.getBlock(itemStack), BasicPlayerShim.getBlockMeta(itemStack), true))
-            return 1;
-        return 0;
+            return 0;
+        return count;
     }
 }


### PR DESCRIPTION
Fixes a bug where the wand would draw infinite blocks from a dirt or
cobble rod, even if they lacked the needed mana. Fixes a bug where the
wand would refuse to work if a dirt or cobble rod was present and had
mana to use.