### PR TITLE
Fix wands not working with both infinite and finite item sources

### DIFF
--- a/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
+++ b/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
@@ -68,7 +68,11 @@ public class BasicPlayerShim implements IPlayerShim {
                 total += Math.max(0, inventoryStack.getCount());
             }
             else {
-                total += containerManager.countItems(containerState, player, itemStack, inventoryStack);
+                int amount = containerManager.countItems(containerState, player, itemStack, inventoryStack);
+                if(amount == Integer.MAX_VALUE) {
+                    return Integer.MAX_VALUE;
+                }
+                total += amount;
             }
         }
 


### PR DESCRIPTION
Fixes a problem where Wands stop working if both the Botania Rod of
the Depths and any amount of actual cobblestone are in the player's
inventory, and any similar problems with other infinite item sources.