### PR TITLE
Add ability for custom `IPlayerShim`s

### DIFF
--- a/src/main/java/portablejim/bbw/core/BlockEvents.java
+++ b/src/main/java/portablejim/bbw/core/BlockEvents.java
@@ -33,18 +33,19 @@ public class BlockEvents {
     @SubscribeEvent
     public void blockHighlightEvent(DrawBlockHighlightEvent event) {
         if(event.getTarget() != null && event.getTarget().typeOfHit == RayTraceResult.Type.BLOCK) {
-            IPlayerShim playerShim = new BasicPlayerShim(event.getPlayer());
-            if(event.getPlayer().capabilities.isCreativeMode) {
-                playerShim = new CreativePlayerShim(event.getPlayer());
-            }
-
-            ItemStack wandItemstack = playerShim.getHeldWandIfAny();
+            ItemStack wandItemstack = BasicPlayerShim.getHeldWandIfAny(event.getPlayer());
             IBlockState state = event.getPlayer().getEntityWorld().getBlockState(event.getTarget().getBlockPos());
 
-            IWorldShim worldShim = new BasicWorldShim(event.getPlayer().getEntityWorld());
-            if(wandItemstack != null && wandItemstack.getItem() instanceof IWandItem) {
+            if(wandItemstack.getItem() instanceof IWandItem) {
                 IWandItem wandItem = (IWandItem) wandItemstack.getItem();
                 IWand wand = wandItem.getWand();
+
+                IPlayerShim playerShim = wandItem.getPlayerShim(event.getPlayer());
+                if(event.getPlayer().capabilities.isCreativeMode) {
+                    playerShim = new CreativePlayerShim(event.getPlayer());
+                }
+
+                IWorldShim worldShim = new BasicWorldShim(event.getPlayer().getEntityWorld());
 
                 WandWorker worker = new WandWorker(wand, playerShim, worldShim);
 

--- a/src/main/java/portablejim/bbw/core/items/IWandItem.java
+++ b/src/main/java/portablejim/bbw/core/items/IWandItem.java
@@ -5,6 +5,7 @@ import net.minecraft.item.ItemStack;
 import portablejim.bbw.basics.EnumFluidLock;
 import portablejim.bbw.core.wands.IWand;
 import portablejim.bbw.basics.EnumLock;
+import portablejim.bbw.shims.IPlayerShim;
 
 /**
  * Identifies classes that should be treated as a wand.
@@ -16,4 +17,5 @@ public interface IWandItem {
     void nextFluidMode(ItemStack itemStack, EntityPlayer player);
     IWand getWand();
     EnumLock getFaceLock(ItemStack itemStack);
+    IPlayerShim getPlayerShim(EntityPlayer player);
 }

--- a/src/main/java/portablejim/bbw/core/items/ItemBasicWand.java
+++ b/src/main/java/portablejim/bbw/core/items/ItemBasicWand.java
@@ -56,7 +56,7 @@ public abstract class ItemBasicWand extends Item implements IWandItem{
         }
 
         if(!world.isRemote) {
-            IPlayerShim playerShim = new BasicPlayerShim(player);
+            IPlayerShim playerShim = getPlayerShim(player);
             if (player.capabilities.isCreativeMode) {
                 playerShim = new CreativePlayerShim(player);
             }
@@ -234,5 +234,10 @@ public abstract class ItemBasicWand extends Item implements IWandItem{
 
     public EnumFluidLock getDefaultFluidMode() {
         return EnumFluidLock.STOPAT;
+    }
+
+    @Override
+    public IPlayerShim getPlayerShim(EntityPlayer player) {
+        return new BasicPlayerShim(player);
     }
 }

--- a/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
+++ b/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
@@ -2,7 +2,6 @@ package portablejim.bbw.shims;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.init.Blocks;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
@@ -11,7 +10,6 @@ import portablejim.bbw.api.IContainerHandlerSpecial;
 import portablejim.bbw.basics.Point3d;
 import portablejim.bbw.containers.ContainerManager;
 import portablejim.bbw.core.items.IWandItem;
-import portablejim.bbw.basics.Point3d;
 import vazkii.botania.api.item.IBlockProvider;
 
 import java.util.ArrayList;
@@ -90,7 +88,7 @@ public class BasicPlayerShim implements IPlayerShim {
         List<ItemStack> providers = new ArrayList<ItemStack>();
         for(int i = player.inventory.mainInventory.size()- 1; i >= 0; i--) {
             ItemStack inventoryStack = player.inventory.mainInventory.get(i);
-            if(inventoryStack != null && itemStack.isItemEqual(inventoryStack)) {
+            if(inventoryStack != ItemStack.EMPTY && itemStack.isItemEqual(inventoryStack)) {
                 if(inventoryStack.getCount() < toUse) {
                     inventoryStack.setCount(0);
                     toUse -= inventoryStack.getCount();
@@ -142,11 +140,11 @@ public class BasicPlayerShim implements IPlayerShim {
     }
 
     public static ItemStack getHeldWandIfAny(EntityPlayer player) {
-        ItemStack wandItem = null;
-        if(player.getHeldItem(EnumHand.MAIN_HAND) != null && player.getHeldItem(EnumHand.MAIN_HAND).getItem() instanceof IWandItem) {
+        ItemStack wandItem = ItemStack.EMPTY;
+        if(player.getHeldItem(EnumHand.MAIN_HAND) != ItemStack.EMPTY && player.getHeldItem(EnumHand.MAIN_HAND).getItem() instanceof IWandItem) {
             wandItem = player.getHeldItem(EnumHand.MAIN_HAND);
         }
-        else if(player.getHeldItem(EnumHand.OFF_HAND) != null && player.getHeldItem(EnumHand.OFF_HAND).getItem() instanceof IWandItem) {
+        else if(player.getHeldItem(EnumHand.OFF_HAND) != ItemStack.EMPTY && player.getHeldItem(EnumHand.OFF_HAND).getItem() instanceof IWandItem) {
             wandItem = player.getHeldItem(EnumHand.OFF_HAND);
         }
         return wandItem;


### PR DESCRIPTION
Changed how `IPlayerShim`s are obtained, allowing for new `IPlayerShim`s to be used.

Changed `BasicPlayerShim`s processing of ItemStacks, as ItemStacks are never null, in favor of `ItemStack.EMPTY`.